### PR TITLE
force_https testing heroku redirect in client code

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,9 @@
+{
+  "root": "build/",
+  "https_only": true,
+  "headers": {
+    "/**": {
+      "Strict-Transport-Security": "max-age=7776000"
+    }
+  }
+}


### PR DESCRIPTION
this makes it so that hitting http will always switch to https in the react client without the need to code a useless expressJS server